### PR TITLE
feat(ui): change navigation animation

### DIFF
--- a/app/src/main/java/com/example/outdoorsy/ui/history/HistoryScreen.kt
+++ b/app/src/main/java/com/example/outdoorsy/ui/history/HistoryScreen.kt
@@ -1,5 +1,6 @@
 package com.example.outdoorsy.ui.history
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -25,7 +26,9 @@ fun HistoryScreen(modifier: Modifier = Modifier, viewModel: HistoryViewModel = h
     val historyItems by viewModel.historyItems.collectAsState()
 
     Column(
-        modifier = modifier.fillMaxSize()
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
     ) {
         // Title
         ScreenTitle(

--- a/app/src/main/java/com/example/outdoorsy/ui/main/AppContainer.kt
+++ b/app/src/main/java/com/example/outdoorsy/ui/main/AppContainer.kt
@@ -1,5 +1,8 @@
 package com.example.outdoorsy.ui.main
 
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -27,18 +30,27 @@ import com.example.outdoorsy.ui.weather.WeatherViewModel
 fun AppContainer(mainNavController: NavHostController) {
     val nestedNavController = rememberNavController()
 
-    Scaffold(
-        bottomBar = {
-            AppBottomNavBar(navController = nestedNavController)
-        }
-    ) { paddingValues ->
-
+    Scaffold(bottomBar = {
+        AppBottomNavBar(navController = nestedNavController)
+    }) { paddingValues ->
         NavHost(
             navController = nestedNavController,
             startDestination = Screen.AppNav.Weather.route,
             modifier = Modifier
                 .padding(paddingValues)
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = 16.dp),
+            enterTransition = {
+                fadeIn(animationSpec = tween(200))
+            },
+            exitTransition = {
+                fadeOut(animationSpec = tween(200))
+            },
+            popEnterTransition = {
+                fadeIn(animationSpec = tween(200))
+            },
+            popExitTransition = {
+                fadeOut(animationSpec = tween(200))
+            }
         ) {
             composable(Screen.AppNav.Weather.route) {
                 val viewModel: WeatherViewModel = hiltViewModel()

--- a/app/src/main/java/com/example/outdoorsy/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/example/outdoorsy/ui/settings/SettingsScreen.kt
@@ -1,6 +1,8 @@
 package com.example.outdoorsy.ui.settings
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -10,6 +12,7 @@ import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -40,7 +43,10 @@ fun SettingsScreen(modifier: Modifier = Modifier, viewModel: SettingsViewModel =
     var showCurrencyDialog by remember { mutableStateOf(false) }
 
     Column(
-        modifier = modifier.verticalScroll(rememberScrollState())
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
     ) {
         // Title Area
         ScreenTitle(title = stringResource(R.string.settings_screen_title))

--- a/app/src/main/java/com/example/outdoorsy/ui/shopping/ShoppingScreen.kt
+++ b/app/src/main/java/com/example/outdoorsy/ui/shopping/ShoppingScreen.kt
@@ -1,7 +1,9 @@
 package com.example.outdoorsy.ui.shopping
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -29,7 +31,9 @@ fun ShoppingScreen(modifier: Modifier = Modifier, viewModel: ShoppingViewModel =
     val uiState by viewModel.uiState.collectAsState()
 
     LazyColumn(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         // 1. Header

--- a/app/src/main/java/com/example/outdoorsy/ui/weather/WeatherScreen.kt
+++ b/app/src/main/java/com/example/outdoorsy/ui/weather/WeatherScreen.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -105,7 +106,10 @@ fun WeatherScreen(modifier: Modifier = Modifier, viewModel: WeatherViewModel = h
         }
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
+    Box(
+        modifier = modifier.fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
         Column(
             modifier = Modifier.verticalScroll(rememberScrollState())
         ) {


### PR DESCRIPTION
Overrides the default navigation animation with a quicker crossfade.

Also, applies the background color from the MaterialTheme to the Weather, History, Shopping, and Settings screens to ensure a consistent look and feel.